### PR TITLE
Avoid `--chmod=755` in Dockerfile.

### DIFF
--- a/ankerctl/Dockerfile
+++ b/ankerctl/Dockerfile
@@ -12,7 +12,7 @@ FROM $BUILD_FROM
 ARG CONFIG_PATH='/data/options.json'
 
 # Add run.sh
-COPY --chmod=755 data/run.sh /
+COPY data/run.sh /
 
 # Set S6 wait time
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \


### PR DESCRIPTION
It seems `--chmod` is only support with a docker add-on. This causes home assistant to give this error:

```
Failed to install add-on

the --chmod option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/
to learn how to build images with BuildKit enabled
```

Since we are calling `sh` as the `ENTRYPOINT`, it doesn't need to be +x anyway.

(yes.. it seems I gave terrible advice :sweat_smile:)