### PR TITLE
Chrivers/run script improvements

### DIFF
--- a/ankerctl/data/run.sh
+++ b/ankerctl/data/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 CONFIG_PATH=/data/options.json
 

--- a/ankerctl/data/run.sh
+++ b/ankerctl/data/run.sh
@@ -4,4 +4,4 @@ CONFIG_PATH=/data/options.json
 
 export FLASK_HOST="$(jq --raw-output '.flask_host // empty' $CONFIG_PATH)"
 
-/app/ankerctl.py webserver run
+exec /app/ankerctl.py webserver run "${@}"


### PR DESCRIPTION
- Allow run.sh to pass extra arguments to ankerctl.py, and exec into it, to avoid a /bin/sh instance.
- Fix shell path. POSIX specifies it to be /bin/sh.